### PR TITLE
add assign sector

### DIFF
--- a/src/assets/scss/components/_dropdown.scss
+++ b/src/assets/scss/components/_dropdown.scss
@@ -25,11 +25,13 @@
 .select-box {
   box-sizing: border-box;
   position: absolute;
-  top: 100%;
+  top: calc(100% + #{$s-gutter-small-half});
   left: 50%;
   width: 100%;
-  min-width: 11.5rem;
+  display: flex;
   flex-direction: column;
+  gap: 0.8rem;
+  min-width: 11.5rem;
   border: 0.1rem solid #e6e4ff;
   border-radius: 0.5rem;
   padding: 0.8rem;
@@ -53,19 +55,26 @@
     box-sizing: border-box;
     border-radius: 0.5rem;
     padding: 0.6rem 0.8rem 0.6rem 1.2rem;
-    display: inline-block;
+    display: flex;
+    gap: 0.5rem;
     width: 100%;
     background-color: #f0f0f7;
     color: #5e5d66;
     font-size: 1rem;
     transition: all 0.2s;
+    align-items: center;
 
     &:hover {
       padding-left: 1.6rem;
+      color: #f65077;
     }
 
     &:active {
       transform: scale(0.95);
+    }
+
+    svg {
+      display: none;
     }
   }
 
@@ -73,18 +82,20 @@
     background-color: #f0f0f7;
     font-weight: bold;
     color: #f65077;
+
+    svg {
+      display: block;
+    }
   }
 
   li + li {
-    margin-top: 0.4rem;
+    margin-top: $s-gutter-small-half;
   }
 
   &__notify {
-    padding: $s-gutter-half $s-gutter-small-half $s-gutter-small-half;
-  }
-
-  .searchbar {
-    margin-top: -0.5rem;
-    margin-bottom: 0.8rem;
+    padding-right: $s-gutter-small-half;
+    padding-left: $s-gutter-small-half;
+    font-size: 1.2rem;
+    color: #5e5d66;
   }
 }

--- a/src/assets/scss/components/_form.scss
+++ b/src/assets/scss/components/_form.scss
@@ -41,7 +41,6 @@
 }
 
 .sheet-creator {
-  margin-top: $s-gutter;
   padding: $s-gutter-half;
   background-color: convert-scheme(sunrise);
   border-radius: 0.5rem;

--- a/src/assets/scss/components/_sheet.scss
+++ b/src/assets/scss/components/_sheet.scss
@@ -1,6 +1,13 @@
 .sheet {
-  display: grid;
-  gap: $s-gutter-half;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  &__row {
+    display: inline-flex;
+    flex-direction: row;
+    gap: 0.5rem;
+  }
 }
 
 .seat {
@@ -12,6 +19,10 @@
   border-radius: 0.5rem;
   background-color: #f0f0f7;
   transition: all 0.2s;
+
+  &[disabled] {
+    cursor: default;
+  }
 
   &:hover {
     transform: scale(1.03);

--- a/src/assets/scss/layouts/_nav.scss
+++ b/src/assets/scss/layouts/_nav.scss
@@ -1,5 +1,8 @@
 .navigation {
+  display: flex;
+  flex-direction: column;
   grid-area: nav;
+  gap: $s-gutter;
   padding: $s-gutter;
   box-shadow: convert-scheme(musk) -2px 2px 6px;
   background-color: convert-scheme(primary);

--- a/src/components/elements/Button.js
+++ b/src/components/elements/Button.js
@@ -1,15 +1,13 @@
 import React from 'react';
-import { BsGrid1X2Fill, BsFillGrid3X3GapFill } from 'react-icons/bs';
-import { AiOutlinePlus } from "react-icons/ai";
-import { BsCheck } from 'react-icons/bs/index';
+import { BsCheck } from 'react-icons/bs';
+import { AiOutlinePlus, AiOutlineClose } from 'react-icons/ai';
 
 const ElementButton = (props) => {
   return (
     <button className={`btn ${props.className}`} disabled={props.disabled} onClick={props.callback}>
       {props.isAdded && <AiOutlinePlus />}
       {props.isChecked && <BsCheck />}
-      {props.addSheet && <BsFillGrid3X3GapFill />}
-      {props.addSector && <BsGrid1X2Fill />}
+      {props.isCancel && <AiOutlineClose />}
       {props.children}
     </button>
   );

--- a/src/components/layouts/Navigation.js
+++ b/src/components/layouts/Navigation.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Logo from '../elements/Logo';
 import SheetCreator from '../modules/SheetCreator';
+import SectorCreator from '../modules/SectorCreator';
 
 const Navigation = () => {
   return (
@@ -8,6 +9,7 @@ const Navigation = () => {
       <Logo />
 
       <SheetCreator />
+      <SectorCreator />
     </aside>
   );
 };

--- a/src/components/modules/Dropdown.js
+++ b/src/components/modules/Dropdown.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { BsChevronDown } from 'react-icons/bs/index';
-import { AiOutlinePlus } from 'react-icons/ai/index';
+import { BsChevronDown } from 'react-icons/bs';
+import { AiOutlinePlus } from 'react-icons/ai';
 import ElementSearchbar from '../elements/Searchbar';
 import ModuleSelectBox from './SelectBox';
 

--- a/src/components/modules/Seat.js
+++ b/src/components/modules/Seat.js
@@ -1,17 +1,50 @@
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { sheetVersion1, currentSectorInfo } from '../../store/atoms';
 
 
 const ModuleSeat = (props) => {
   const seatRef = useRef(null);
+  const [organizationSheet] = useRecoilState(sheetVersion1);
+  const [currentSector] = useRecoilState(currentSectorInfo);
 
-  const onClick = () => {
+  const deactiveSeatColor = '#f0f0f7';
+  const activeSeatColor = currentSector?.color || '#c9c9d4';
+
+  const onSelectSeat = () => {
     const seatElem = seatRef.current;
-    seatElem.style.backgroundColor = '#C9C9D4';
-    props.selectSeat(props.seatId);
+    props.onSelectSeat(props.seatId);
+
+    if (seatElem.dataset.sectorId) {
+      delete seatElem.dataset.sectorId;
+      seatElem.style.backgroundColor = deactiveSeatColor;
+    } else {
+      seatElem.dataset.sectorId = currentSector.id;
+      seatElem.style.backgroundColor = activeSeatColor;
+    }
   };
 
+  useEffect(() => {
+    const seatElem = seatRef.current;
+    organizationSheet?.map((organization) => {
+      organization.sheet.map((seat) => {
+        if (seat.locate.toString() === seatElem.dataset.seatId) {
+          seatElem.dataset.sectorId = organization.id;
+          seatElem.style.backgroundColor = organization.color;
+        }
+      });
+    });
+  }, [organizationSheet]);
+
   return (
-    <button id={props.seatId} ref={seatRef} className="seat" onClick={onClick}>
+    <button
+      ref={seatRef}
+      className="seat"
+      data-seat-id={props.seatId}
+      style={{ backgroundColor: deactiveSeatColor }}
+      disabled={!currentSector}
+      onClick={onSelectSeat}
+    >
       {/*홍길동*/}
     </button>
   );

--- a/src/components/modules/SelectBox.js
+++ b/src/components/modules/SelectBox.js
@@ -1,46 +1,54 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ElementButton from '../elements/Button';
+import { BsCheck } from 'react-icons/bs';
 
 const ModuleSelectBox = (props) => {
+  const [selectItem, setSelectItem] = useState(null);
+
+  const onClickItem = (item) => {
+    setSelectItem(item);
+  };
+
+  const onSubmit = () => {
+    props.onSubmit(selectItem);
+  };
 
   return (
     <div className="select-box">
       {props.children}
+
       <ul className="select-box__list">
         {props.list?.map((item) => (
-          <li key={item.id} onClick={() => props.onClickItem(item)}>
+          <li key={item.id} onClick={() => onClickItem(item)}>
             <input
               id={`select-box-${item.id}`}
               className="a11y"
-              type={props.listType || 'checkbox' }
               name={props.listLabel || ''}
+              type={props.listType || 'checkbox' }
             />
-            <label htmlFor={`select-box-${item.id}`}>{item.name}</label>
+            <label htmlFor={`select-box-${item.id}`}>
+              <BsCheck />{item.title}
+            </label>
           </li>
         ))}
       </ul>
 
       {props.notificationLabel && (
-        <p className="select-box__notify" dangerouslySetInnerHTML={ {__html: props.notificationLabel} } />
+        <p
+          className="select-box__notify"
+          dangerouslySetInnerHTML={ {__html: props.notificationLabel} }
+        />
       )}
 
       <div className="btn-set btn-set--content">
-        {props.isCancel && (
-          <ElementButton
-            isCancel
-            className="btn--thin btn--secondary"
-            callback={props.onCancel}
-          />
-        )}
-        {props.isConfirm && (
-          <ElementButton
-            isChecked
-            className="btn--thin btn--secondary"
-            callback={props.onSubmit}
-          >
-            {props.confirmLabel}
-          </ElementButton>
-        )}
+        <ElementButton
+          isChecked
+          disabled={!selectItem}
+          className="btn--thin"
+          callback={onSubmit}
+        >
+          {props.confirmLabel}
+        </ElementButton>
       </div>
     </div>
   );

--- a/src/components/modules/Sheet.js
+++ b/src/components/modules/Sheet.js
@@ -1,33 +1,37 @@
-import React, { useState } from 'react';
+import React, { useEffect }  from 'react';
 import { useRecoilState } from 'recoil';
 
 import ModuleSeat from './Seat';
-import { sheetMap } from '../../store/atoms';
+import { sheetMap, selectedSeatMap } from '../../store/atoms';
 
 const ModuleSheet = () => {
   const [sheet] = useRecoilState(sheetMap);
-  const [col, row] = sheet;
-  const [selectedSeats, setSelectedSeats] = useState([]);
+  const [selectedSeats, setSelectedSeats] = useRecoilState(selectedSeatMap);
 
-  const selectSeat = (seatId) => {
-    if (selectedSeats.find((id) => id === seatId)) return;
-    setSelectedSeats((state) => {
-      return [...state, seatId];
-    });
+  const [col, row] = sheet;
+  const colLocateMap = Array.from({ length: col }, (v, i) => i);
+  const rowLocateMap = Array.from({ length: row }, (v, i) => i);
+
+  const onSelectSeat = (seatId) => {
+    // 이미 선택된 시트를 선택 할 경우, 선택이 취소됨.
+    const alreadySelected = selectedSeats.find((id) => id === seatId);
+    const filteredSeats = selectedSeats.filter((id) => id !== seatId);
+
+    setSelectedSeats((state) => alreadySelected ? [...filteredSeats] : [...state, seatId]);
   };
 
-  const locateMap = Array.from({ length: col * row }, (v, i) => i);
+  useEffect(() => {
+    console.log(selectedSeats);
+  }, [selectedSeats]);
 
   return (
-    <div
-      className="sheet"
-      style={{
-        gridTemplateColumns: `repeat(${col}, 1fr)`,
-        gridTemplateRows: `repeat(${row}, 1fr)`,
-      }}
-    >
-      {locateMap.map((seatId) => (
-        <ModuleSeat key={seatId} seatId={seatId} selectSeat={selectSeat} />
+    <div className="sheet">
+      {rowLocateMap?.map((row) => (
+        <div className="sheet__row" key={row}>
+          {colLocateMap?.map((col) => (
+            <ModuleSeat key={col} seatId={`${row},${col}`} onSelectSeat={onSelectSeat} />
+          ))}
+        </div>
       ))}
     </div>
   );

--- a/src/mock/index.js
+++ b/src/mock/index.js
@@ -1,0 +1,124 @@
+export const sheet = {
+  row: 6,
+  col: 10,
+}
+
+export const responseOrganizations = [
+  {
+    id: 0,
+    title: '개발실',
+    color: 'rgb(255, 240, 139)',
+    member: [
+      {
+        memberId: 0,
+        name: 'choi',
+      },
+      {
+        memberId: 1,
+        name: 'jeon',
+      },
+      {
+        memberId: 2,
+        name: 'joo',
+      },
+    ],
+  },
+  {
+    id: 1,
+    title: '기획팀',
+    color: 'rgb(156, 235, 206)',
+    member: [
+      {
+        memberId: 0,
+        name: 'kim',
+      },
+      {
+        memberId: 1,
+        name: 'choi',
+      },
+    ],
+  },
+  {
+    id: 2,
+    title: '디자인팀',
+    color: 'rgb(230, 206, 255)',
+    member: {
+      memberId: 0,
+      name: 'kang',
+    }
+  },
+];
+
+export const responseSheetVersion1 = [
+  {
+    id: 0,
+    title: '개발실',
+    color: 'rgb(255, 240, 139)',
+    sheet: [
+      {
+        memberId: 0,
+        member: 'jeon',
+        locate: [0, 0],
+      },
+      {
+        memberId: 1,
+        member: 'choi',
+        locate: [0, 1],
+      },
+      {
+        memberId: 2,
+        member: 'joo',
+        locate: [0, 2],
+      },
+      {
+        memberId: 3,
+        member: null, // 개발실에 예약된 좌석
+        locate: [1, 0],
+      },
+    ]
+  },
+  {
+    id: 1,
+    title: '기획팀',
+    color: 'rgb(156, 235, 206)',
+    sheet: [
+      {
+        memberId: 0,
+        member: 'kim',
+        locate: [3, 0],
+      },
+      {
+        memberId: 1,
+        member: null,
+        locate: [3, 1],
+      },
+      {
+        memberId: 2,
+        member: null,
+        locate: [3, 2],
+      },
+    ]
+  },
+  {
+    id: 2,
+    title: '디자인팀',
+    color: 'rgb(230, 206, 255)',
+    sheet: [
+      {
+        memberId: 0,
+        member: 'kang',
+        locate: [0, 4],
+      },
+      {
+        memberId: 1,
+        member: null,
+        locate: [3, 3],
+      },
+      {
+        memberId: 1,
+        member: null,
+        locate: [3, 4],
+      },
+    ]
+  },
+];

--- a/src/store/atoms.js
+++ b/src/store/atoms.js
@@ -1,6 +1,28 @@
 import { atom } from 'recoil';
+import { responseOrganizations, responseSheetVersion1 } from '../mock';
 
 export const sheetMap = atom({
   key: 'sheetMap',
-  default: [3, 3],
+  default: [5, 4],
+});
+
+export const currentSectorInfo = atom({
+  key: 'currentSectorInfo',
+  default: null,
+});
+
+// todo: currentSectorInfo 의 sheet 배열이 초기값이 되도록 수정
+export const selectedSeatMap = atom({
+  key: 'selectedSeatMap',
+  default: [],
+});
+
+export const organizationList = atom({
+  key: 'responseOrganizations',
+  default: responseOrganizations,
+});
+
+export const sheetVersion1 = atom({
+  key: 'responseSheetVersion1',
+  default: responseSheetVersion1,
 });


### PR DESCRIPTION
- mock data
  - 조직도 (`responseOrganizations`)
  - 생성된 시트 정보 (`responseSheetVersion1`)

- create sector
  - 네비게이션에 sector creator dropdown 배치
  - 조직이 선택되어야 시트가 활성화
  - 선택된 조직의 컬러 값으로 sector 구성
  - sector 구성 중 리셋, 선택한 sector 의 seat 선택 취소 부분 보완 예정 (todo)

- 잔여 테스크
  - seat 에 직원 배정
  - 동일한 sector 에 배정된 직원 시퀀스 변경 (dnd)

<img width="690" alt="스크린샷 2021-08-29 오전 11 31 29" src="https://user-images.githubusercontent.com/55912548/131236242-2842b523-1af1-41bc-9c90-2c7367444369.png">
